### PR TITLE
single_cls_val

### DIFF
--- a/ultralytics/cfg/default-IR.yaml
+++ b/ultralytics/cfg/default-IR.yaml
@@ -8,6 +8,7 @@ device: 0 # (int | str | list, optional) device to run on, i.e. cuda device=0 or
 workers: 8 # (int) number of worker threads for data loading (per RANK if DDP)
 pretrained: True # (bool | str) whether to use a pretrained model (bool) or a model to load weights from (str)
 single_cls: False # (bool) train multi-class data as single-class
+single_cls_val: False #(bool) validate as single-class data regardless of training being in multi-class mode
 close_mosaic: 10 # (int) disable mosaic augmentation for final epochs (0 to disable)
 
 # Predict settings -----------------------------------------------------------------------------------------------------

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -26,6 +26,7 @@ verbose: True # (bool) whether to print verbose output
 seed: 0 # (int) random seed for reproducibility
 deterministic: True # (bool) whether to enable deterministic mode
 single_cls: False # (bool) train multi-class data as single-class
+single_cls_val: False #(bool) validate as single-class data regardless of training being in multi-class mode
 rect: False # (bool) rectangular training if mode='train' or rectangular validation if mode='val'
 cos_lr: False # (bool) use cosine learning rate scheduler
 close_mosaic: 10 # (int) disable mosaic augmentation for final epochs (0 to disable)

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -84,6 +84,10 @@ def seed_worker(worker_id):  # noqa
 def build_yolo_dataset(cfg, img_path, batch, data, mode="train", rect=False, stride=32, multi_modal=False):
     """Build YOLO Dataset."""
     dataset = YOLOMultiModalDataset if multi_modal else YOLODataset
+    if mode == "val":
+        single_cls = cfg.single_cls_val or cfg.single_cls or False
+    else:
+        single_cls = cfg.single_cls or False
     return dataset(
         img_path=img_path,
         imgsz=cfg.imgsz,
@@ -92,7 +96,7 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode="train", rect=False, str
         hyp=cfg,  # TODO: probably add a get_hyps_from_cfg function
         rect=cfg.rect or rect,  # rectangular batches
         cache=cfg.cache or None,
-        single_cls=cfg.single_cls or False,
+        single_cls= single_cls,
         stride=int(stride),
         pad=0.0 if mode == "train" else 0.5,
         prefix=colorstr(f"{mode}: "),

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -93,8 +93,10 @@ class DetectionTrainer(BaseTrainer):
     def get_validator(self):
         """Returns a DetectionValidator for YOLO model validation."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
+        val_args = copy(self.args)
+        val_args.single_cls = val_args.single_cls_val        
         return yolo.detect.DetectionValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=val_args, _callbacks=self.callbacks
         )
 
     def label_loss_items(self, loss_items=None, prefix="train"):
@@ -106,6 +108,7 @@ class DetectionTrainer(BaseTrainer):
         keys = [f"{prefix}/{x}" for x in self.loss_names]
         if loss_items is not None:
             loss_items = [round(float(x), 5) for x in loss_items]  # convert tensors to 5 decimal place floats
+            loss_items[1] = 0 if prefix == "val" else loss_items[1] # if single_cls_val, set cls_loss to 0   
             return dict(zip(keys, loss_items))
         else:
             return keys

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -93,10 +93,8 @@ class DetectionTrainer(BaseTrainer):
     def get_validator(self):
         """Returns a DetectionValidator for YOLO model validation."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
-        val_args = copy(self.args)
-        val_args.single_cls = val_args.single_cls_val        
         return yolo.detect.DetectionValidator(
-            self.test_loader, save_dir=self.save_dir, args=val_args, _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
 
     def label_loss_items(self, loss_items=None, prefix="train"):

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -78,8 +78,8 @@ class DetectionValidator(BaseValidator):
         self.is_lvis = isinstance(val, str) and "lvis" in val and not self.is_coco  # is LVIS
         self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(len(model.names)))
         self.args.save_json |= self.args.val and (self.is_coco or self.is_lvis) and not self.training  # run final val
-        self.names = model.names
-        self.nc = len(model.names)
+        self.names = {0: "item"} if self.args.single_cls or self.args.single_cls_val else model.names
+        self.nc = 1 if self.args.single_cls or self.args.single_cls_val else len(model.names)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
         self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -37,6 +37,7 @@ class DetectionValidator(BaseValidator):
         self.is_lvis = False
         self.class_map = None
         self.args.task = "detect"
+        self.args.single_cls = self.args.single_cls_val
         self.metrics = DetMetrics(save_dir=self.save_dir, on_plot=self.on_plot, args=self.args)
         mAP_lb = 0.5 if not hasattr(self.args, 'mAP_lb') else self.args.mAP_lb
         mAP_ub = 0.95 if not hasattr(self.args, 'mAP_ub') else self.args.mAP_ub


### PR DESCRIPTION
## What?
 
We want to have the possibility to, during training, do the validation step as single class, even when training as multi-cass.
 
## Why?
 
our main requirement for cnn training is identification, rather then classification.
with this approach we can cut out the need to upload our cnns to fiftyone to get a first feeling on identification performance

## How?
 
we add:

single_cls_val: False #(bool) validate as single-class data regardless of training being in multi-class mode

to default.yaml and defaul-IR.yaml

this variable is then accessed in several places:
- ```ultralytics/data/build.py```
- ```ultralytics/models/yolo/detect/val.py```
- ```ultralytics/models/yolo/detect/train.py```

To train as multi class and validate as single_cls simply do:

```model.train(data=data, epochs=1, project="ultralytics", name="yolo11n-single-cls-val", cfg=cfg, single_cls_val=True)```

## Backout plan

Revert commits :D

## Testing

![Screenshot from 2024-12-05 14-21-51](https://github.com/user-attachments/assets/3b5f94ba-2f09-4e7e-910b-809a5a0131d9)

![Screenshot from 2024-12-05 14-59-55](https://github.com/user-attachments/assets/3eb65265-408d-4100-8817-71666e30a791)


