### PR TITLE
Cv 221 make ultralytics m ap agnostic clean

### DIFF
--- a/ultralytics/cfg/default-IR.yaml
+++ b/ultralytics/cfg/default-IR.yaml
@@ -8,6 +8,7 @@ device: 0 # (int | str | list, optional) device to run on, i.e. cuda device=0 or
 workers: 8 # (int) number of worker threads for data loading (per RANK if DDP)
 pretrained: True # (bool | str) whether to use a pretrained model (bool) or a model to load weights from (str)
 single_cls: False # (bool) train multi-class data as single-class
+single_cls_val: True # (bool) validate multi-class data as single-class regardless of train mode
 close_mosaic: 10 # (int) disable mosaic augmentation for final epochs (0 to disable)
 
 # Predict settings -----------------------------------------------------------------------------------------------------

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -26,6 +26,7 @@ verbose: True # (bool) whether to print verbose output
 seed: 0 # (int) random seed for reproducibility
 deterministic: True # (bool) whether to enable deterministic mode
 single_cls: False # (bool) train multi-class data as single-class
+single_cls_val: True # (bool) validate multi-class data as single-class regardless of train mode
 rect: False # (bool) rectangular training if mode='train' or rectangular validation if mode='val'
 cos_lr: False # (bool) use cosine learning rate scheduler
 close_mosaic: 10 # (int) disable mosaic augmentation for final epochs (0 to disable)

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -2,7 +2,7 @@
 
 import math
 import random
-from copy import copy
+from copy import copy, deepcopy
 
 import numpy as np
 import torch.nn as nn
@@ -40,8 +40,13 @@ class DetectionTrainer(BaseTrainer):
             batch (int, optional): Size of batches, this is for `rect`. Defaults to None.
         """
         gs = max(int(de_parallel(self.model).stride.max() if self.model else 0), 32)
-        return build_yolo_dataset(self.args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
-
+        if mode == "val":
+            val_args = deepcopy(self.args)
+            val_args.single_cls = val_args.single_cls_val
+            return build_yolo_dataset(val_args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
+        else:
+            return build_yolo_dataset(self.args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
+        
     def get_dataloader(self, dataset_path, batch_size=16, rank=0, mode="train"):
         """Construct and return dataloader."""
         assert mode in {"train", "val"}, f"Mode must be 'train' or 'val', not {mode}."
@@ -93,8 +98,10 @@ class DetectionTrainer(BaseTrainer):
     def get_validator(self):
         """Returns a DetectionValidator for YOLO model validation."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
+        val_args = deepcopy(self.args)
+        val_args.single_cls = val_args.single_cls_val        
         return yolo.detect.DetectionValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=val_args, _callbacks=self.callbacks
         )
 
     def label_loss_items(self, loss_items=None, prefix="train"):

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -113,6 +113,7 @@ class DetectionTrainer(BaseTrainer):
         keys = [f"{prefix}/{x}" for x in self.loss_names]
         if loss_items is not None:
             loss_items = [round(float(x), 5) for x in loss_items]  # convert tensors to 5 decimal place floats
+            loss_items[1] = 0 if (prefix == "val" and self.args.single_cls_val) else loss_items[1] # if single_cls_val, set cls_loss to 0   
             return dict(zip(keys, loss_items))
         else:
             return keys

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -78,8 +78,8 @@ class DetectionValidator(BaseValidator):
         self.is_lvis = isinstance(val, str) and "lvis" in val and not self.is_coco  # is LVIS
         self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(len(model.names)))
         self.args.save_json |= self.args.val and (self.is_coco or self.is_lvis) and not self.training  # run final val
-        self.names = model.names
-        self.nc = len(model.names)
+        self.names = {0: "item"} if self.args.single_cls else model.names
+        self.nc = 1 if self.args.single_cls else len(model.names)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
         self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)


### PR DESCRIPTION
## What?
 
We want to have the possibility to, during training, do the validation step as single class, even when training as multi-cass.
 
## Why?
 
our main requirement for cnn training is identification, rather then classification.
with this approach we can cut out the need to upload our cnns to fiftyone to get a first feeling on identification performance
 
## How?
 
we add:

single_cls_val: False #(bool) validate as single-class data regardless of training being in multi-class mode to default.yaml and defaul-IR.yaml

this variable is then accessed in two methods:
- ```ultralytics/models/yolo/detect/train/get_validator``` which override the ```single_cls``` value in ```DetectionValidator``` object
- ```ultralytics/models/yolo/detect/train/build_yolo_dataset``` which overrides the ```single_cls``` value in ```build_yolo_dataset``` method

Also, the ```self.names``` and ```self.nc```, in  the ```DetectionValidator``` object are overwriten in case of ```single_cls_val=True```, otherwise confusion matrices would include all classes since it gets their dimensions from the model object.

## Backout plan

undo commits :D
 
## Testing

![Screenshot from 2024-12-05 18-14-40](https://github.com/user-attachments/assets/b0c567bb-fcc7-4a30-9794-f1481f137fd4)

as you can see, recall and precision are much bigger when doing slingle_cls_validation, as expected

the model still has multi class data as seen below:

![Screenshot from 2024-12-05 18-16-22](https://github.com/user-attachments/assets/16db1d43-23e6-464a-8c15-2355581cd5d0)



 