### PR TITLE
Cleaner `single_cls{_val}` implementation

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -148,26 +148,15 @@ class BaseDataset(Dataset):
             if self.single_cls:
                 self.labels[i]["cls"][:, 0] = 0
 
-    def imread_16bit_compatible(self,f: str) -> np.ndarray:
-        """
-        Loads an image and returns it in BGR format, it
-        converts 16-bit images to 8-bit with optional augmentation.
-    
-        Args:
-            f (str): Image file path.
-            augment16 (bool): Apply augmentation during conversion from 16-bit to 8bit.
-    
-        Returns:
-            np.ndarray: Image in BGR format.
-        """
-        # Read image with OpenCV, convert from 16-bit to 8-bit if necessary
+    def imread_16bit_compatible(self, f: str) -> np.ndarray:
+        """Read image with OpenCV, convert from 16-bit to 8-bit if necessary"""
         im = cv2.imread(f, cv2.IMREAD_UNCHANGED)  # load image as BGR if 3-ch image
         if im.dtype == np.uint8 and (im.ndim == 2 or im.shape[-1] == 1):
-            im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR) # BGR    
+            im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)  # BGR
         if im.dtype == np.uint16:
             try:
                 from .augment16 import convert_16bit_to_8bit
-    
+
                 im = convert_16bit_to_8bit(im, augment=self.augment)  # GRAY as BGR
             except Exception as e:
                 print(f"WARNING: Failed to convert image {f} from 16-bit to 8-bit")

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -104,7 +104,7 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode="train", rect=False, str
         hyp=cfg,  # TODO: probably add a get_hyps_from_cfg function
         rect=cfg.rect or rect,  # rectangular batches
         cache=cfg.cache or None,
-        single_cls=cfg.single_cls or False,
+        single_cls=cfg.single_cls or (cfg.single_cls_val if mode == "val" else False),
         stride=int(stride),
         pad=0.0 if mode == "train" else 0.5,
         prefix=colorstr(f"{mode}: "),

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -567,6 +567,10 @@ class BaseTrainer:
         except Exception as e:
             raise RuntimeError(emojis(f"Dataset '{clean_url(self.args.data)}' error ❌ {e}")) from e
         self.data = data
+        if self.args.single_cls:
+            LOGGER.info("Overriding class names with single class")
+            self.data["names"] = {0: "item"}
+            self.data["nc"] = 1
         return data["train"], data.get("val") or data.get("test")
 
     def setup_model(self):

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -40,12 +40,7 @@ class DetectionTrainer(BaseTrainer):
             batch (int, optional): Size of batches, this is for `rect`. Defaults to None.
         """
         gs = max(int(de_parallel(self.model).stride.max() if self.model else 0), 32)
-        if mode == "val":
-            val_args = deepcopy(self.args)
-            val_args.single_cls = val_args.single_cls_val
-            return build_yolo_dataset(val_args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
-        else:
-            return build_yolo_dataset(self.args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
+        return build_yolo_dataset(self.args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
         
     def get_dataloader(self, dataset_path, batch_size=16, rank=0, mode="train"):
         """Construct and return dataloader."""
@@ -98,10 +93,8 @@ class DetectionTrainer(BaseTrainer):
     def get_validator(self):
         """Returns a DetectionValidator for YOLO model validation."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
-        val_args = deepcopy(self.args)
-        val_args.single_cls = val_args.single_cls_val        
         return yolo.detect.DetectionValidator(
-            self.test_loader, save_dir=self.save_dir, args=val_args, _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=self.args, _callbacks=self.callbacks
         )
 
     def label_loss_items(self, loss_items=None, prefix="train"):

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -38,8 +38,8 @@ class DetectionValidator(BaseValidator):
         self.class_map = None
         self.args.task = "detect"
         self.metrics = DetMetrics(save_dir=self.save_dir, on_plot=self.on_plot, args=self.args)
-        mAP_lb = 0.5 if not hasattr(self.args, 'mAP_lb') else self.args.mAP_lb
-        mAP_ub = 0.95 if not hasattr(self.args, 'mAP_ub') else self.args.mAP_ub
+        mAP_lb = self.args.mAP_lb
+        mAP_ub = self.args.mAP_ub
         self.iouv = torch.linspace(mAP_lb, mAP_ub, 10)  # iou vector for mAP@mAP_lb:mAP_ub
         self.niou = self.iouv.numel()
         self.lb = []  # for autolabelling
@@ -78,8 +78,8 @@ class DetectionValidator(BaseValidator):
         self.is_lvis = isinstance(val, str) and "lvis" in val and not self.is_coco  # is LVIS
         self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(1, len(model.names) + 1))
         self.args.save_json |= self.args.val and (self.is_coco or self.is_lvis) and not self.training  # run final val
-        self.names = {0: "item"} if self.args.single_cls else model.names
-        self.nc = 1 if self.args.single_cls else len(model.names)
+        self.names = model.names
+        self.nc = len(self.names)
         self.end2end = getattr(model, "end2end", False)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
@@ -90,8 +90,8 @@ class DetectionValidator(BaseValidator):
 
     def get_desc(self):
         """Return a formatted string summarizing class metrics of YOLO model."""
-        mAP_lb = "50" if not hasattr(self.args, "mAP_lb") else f"{int(self.args.mAP_lb * 100):02d}"
-        mAP_ub = "95" if not hasattr(self.args, "mAP_ub") else f"{int(self.args.mAP_ub * 100):02d}"
+        mAP_lb = f"{int(self.args.mAP_lb * 100):02d}"
+        mAP_ub = f"{int(self.args.mAP_ub * 100):02d}"
         return ("%22s" + "%11s" * 6) % ("Class", "Images", "Instances", "Box(P", "R", f"mAP{mAP_lb}", f"mAP{mAP_lb}-{mAP_ub})")
 
     def postprocess(self, preds):
@@ -103,7 +103,7 @@ class DetectionValidator(BaseValidator):
             labels=self.lb,
             nc=self.nc,
             multi_label=True,
-            agnostic=self.args.single_cls or self.args.agnostic_nms,
+            agnostic=self.args.single_cls or self.args.single_cls_val or self.args.agnostic_nms,
             max_det=self.args.max_det,
             end2end=self.end2end,
             rotated=self.args.task == "obb",
@@ -154,7 +154,7 @@ class DetectionValidator(BaseValidator):
                 continue
 
             # Predictions
-            if self.args.single_cls:
+            if self.args.single_cls or self.args.single_cls_val:
                 pred[:, 5] = 0
             predn = self._prepare_pred(pred, pbatch)
             stat["conf"] = predn[:, 4]


### PR DESCRIPTION
## What?
 
Model trained when `single_cls=True` has indeed only one class.
 
## Why?
 
It is what I would expect when training a single class model to assess only detection.
 
## How?
 
Override the `data["names"]` and `data["nc"]` in the dataset builder if `single_cls=True`.

## Backout plan

Delete `if` condition in `trainer.py`
 
## Testing

### Before

```console
engine/trainer: task=detect, mode=train, model=yolo11n.pt, data=/mnt/datasets/yolo/TRAIN_BB_THERMAL_2024_09/dataset.yaml, epochs=100, time=None, patience=100, batch=-1, imgsz=640, save=True, save_period=-1, cache=False, device=0, workers=8, project=ultralytics, name=yolo11n, exist_ok=False, pretrained=True, optimizer=auto, verbose=True, seed=0, deterministic=True, single_cls=True, rect=False, cos_lr=False, close_mosaic=10, resume=False, amp=True, fraction=1.0, profile=False, freeze=None, multi_scale=False, overlap_mask=True, mask_ratio=4, dropout=0.0, val=True, split=val, save_json=False, save_hybrid=False, conf=0.1, iou=0.1, max_det=100, half=False, dnn=False, plots=True, source=None, vid_stride=1, stream_buffer=False, visualize=False, augment=False, agnostic_nms=True, classes=None, retina_masks=False, embed=None, show=False, save_frames=False, save_txt=False, save_conf=False, save_crop=False, show_labels=True, show_conf=True, show_boxes=True, line_width=None, format=torchscript, keras=False, optimize=False, int8=False, dynamic=False, simplify=True, opset=None, workspace=None, nms=False, lr0=0.001, lrf=0.01, momentum=0.937, weight_decay=0.0005, warmup_epochs=3.0, warmup_momentum=0.8, warmup_bias_lr=0.1, box=7.5, cls=0.5, dfl=1.5, pose=12.0, kobj=1.0, nbs=64, hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, degrees=10.0, translate=0.1, scale=0.25, shear=0.0, perspective=0.0, flipud=0.0, fliplr=0.5, bgr=0.0, mosaic=1.0, mixup=0.0, copy_paste=0.0, copy_paste_mode=flip, auto_augment=randaugment, erasing=0.4, crop_fraction=1.0, cfg=../ultralytics/ultralytics/cfg/custom.yaml, tracker=botsort.yaml, save_dir=ultralytics/yolo11n
Overriding model.yaml nc=80 with nc=10
```
 
![image](https://github.com/user-attachments/assets/ed29ebdf-7605-4a52-a532-190f23b552e3)

### After


```console
engine/trainer: task=detect, mode=train, model=yolo11n.pt, data=/mnt/datasets/yolo/TRAIN_BB_THERMAL_2024_09/dataset.yaml, epochs=100, time=None, patience=100, batch=-1, imgsz=640, save=True, save_period=-1, cache=False, device=0, workers=8, project=ultralytics, name=yolo11n, exist_ok=False, pretrained=True, optimizer=auto, verbose=True, seed=0, deterministic=True, single_cls=True, rect=False, cos_lr=False, close_mosaic=10, resume=False, amp=True, fraction=1.0, profile=False, freeze=None, multi_scale=False, overlap_mask=True, mask_ratio=4, dropout=0.0, val=True, split=val, save_json=False, save_hybrid=False, conf=0.1, iou=0.1, max_det=100, half=False, dnn=False, plots=True, source=None, vid_stride=1, stream_buffer=False, visualize=False, augment=False, agnostic_nms=True, classes=None, retina_masks=False, embed=None, show=False, save_frames=False, save_txt=False, save_conf=False, save_crop=False, show_labels=True, show_conf=True, show_boxes=True, line_width=None, format=torchscript, keras=False, optimize=False, int8=False, dynamic=False, simplify=True, opset=None, workspace=None, nms=False, lr0=0.001, lrf=0.01, momentum=0.937, weight_decay=0.0005, warmup_epochs=3.0, warmup_momentum=0.8, warmup_bias_lr=0.1, box=7.5, cls=0.5, dfl=1.5, pose=12.0, kobj=1.0, nbs=64, hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, degrees=10.0, translate=0.1, scale=0.25, shear=0.0, perspective=0.0, flipud=0.0, fliplr=0.5, bgr=0.0, mosaic=1.0, mixup=0.0, copy_paste=0.0, copy_paste_mode=flip, auto_augment=randaugment, erasing=0.4, crop_fraction=1.0, cfg=../ultralytics/ultralytics/cfg/custom.yaml, tracker=botsort.yaml, save_dir=ultralytics/yolo11n
Overriding model.yaml nc=80 with nc=1
```

![image](https://github.com/user-attachments/assets/14c9af68-f44c-4f0c-886d-e01e040363cd)
