### PR TITLE
Robust imread 16bit compatible function

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -166,7 +166,7 @@ class BaseDataset(Dataset):
             im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR) # BGR    
         if im.dtype == np.uint16:
             try:
-                from utils.albumentations16 import convert_16bit_to_8bit
+                from .augment16 import convert_16bit_to_8bit
     
                 im = convert_16bit_to_8bit(im, augment=augment16)  # GRAY as BGR
             except Exception as e:

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -148,14 +148,29 @@ class BaseDataset(Dataset):
             if self.single_cls:
                 self.labels[i]["cls"][:, 0] = 0
 
-    def imread(self, f):
-        im = cv2.imread(f, cv2.IMREAD_UNCHANGED)
-        if im is not None and im.dtype == np.uint16:
+    def imread_16bit_compatible(f: str, augment16: bool = False) -> np.ndarray:
+        """
+        Loads an image and returns it in BGR format, it
+        converts 16-bit images to 8-bit with optional augmentation.
+    
+        Args:
+            f (str): Image file path.
+            augment16 (bool): Apply augmentation during conversion from 16-bit to 8bit.
+    
+        Returns:
+            np.ndarray: Image in BGR format.
+        """
+        # Read image with OpenCV, convert from 16-bit to 8-bit if necessary
+        im = cv2.imread(f, cv2.IMREAD_UNCHANGED)  # load image as BGR if 3-ch image
+        if im.dtype == np.uint8 and (im.ndim == 2 or im.shape[-1] == 1):
+            im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR) # BGR    
+        if im.dtype == np.uint16:
             try:
-                from .augment16 import convert_16bit_to_8bit
-                im = convert_16bit_to_8bit(im, augment=self.augment)
+                from utils.albumentations16 import convert_16bit_to_8bit
+    
+                im = convert_16bit_to_8bit(im, augment=augment16)  # GRAY as BGR
             except Exception as e:
-                print(f'WARNING: Failed to convert image {f} from 16-bit to 8-bit')
+                print(f"WARNING: Failed to convert image {f} from 16-bit to 8-bit")
                 raise e
         return im
 
@@ -171,7 +186,7 @@ class BaseDataset(Dataset):
                     Path(fn).unlink(missing_ok=True)
                     im = cv2.imread(f)  # BGR
             else:  # read image
-                im = self.imread(f)  # BGR
+                im = self.imread_16bit_compatible(f)  # BGR
             if im is None:
                 raise FileNotFoundError(f"Image Not Found {f}")
 
@@ -217,7 +232,7 @@ class BaseDataset(Dataset):
         """Saves an image as an *.npy file for faster loading."""
         f = self.npy_files[i]
         if not f.exists():
-            np.save(f.as_posix(), self.imread(self.im_files[i]), allow_pickle=False)
+            np.save(f.as_posix(), self.imread_16bit_compatible(self.im_files[i]), allow_pickle=False)
 
     def check_cache_disk(self, safety_margin=0.5):
         """Check image caching requirements vs available disk space."""
@@ -252,7 +267,7 @@ class BaseDataset(Dataset):
         b, gb = 0, 1 << 30  # bytes of cached images, bytes per gigabytes
         n = min(self.ni, 30)  # extrapolate from 30 random images
         for _ in range(n):
-            im = self.imread(random.choice(self.im_files))  # sample image
+            im = self.imread_16bit_compatible(random.choice(self.im_files))  # sample image
             if im is None:
                 continue
             ratio = self.imgsz / max(im.shape[0], im.shape[1])  # max(h, w)  # ratio


### PR DESCRIPTION
## What?
 
Always read images a 3channel BGR similar to what `cv2.imread(filepath)` does.
 
## Why?
 
Ultralytics framework expects that always.
 
## How?
 
Add more logic to the 16-compatible imread function.

## Backout plan

Go back to using pure `cv2.imread`.
