### PR TITLE
Enable CLAHE in validation preprocessing

### DIFF
--- a/ultralytics/data/augment16.py
+++ b/ultralytics/data/augment16.py
@@ -45,7 +45,7 @@ def get_16_to_8_transform(augment):
         return A.Compose(
             [
                 Clip(p=1.0, lower_limit=(llimit, llimit), upper_limit=(ulimit, ulimit)),
-                CLAHE(p=0.0, clip_limit=(4, 4), tile_grid_size=(0, 0)),
+                CLAHE(p=1.0, clip_limit=(4, 4), tile_grid_size=(0, 0)),
                 NormalizeMinMax(p=1.0),
                 A.UnsharpMask(p=0.0, threshold=5),
                 A.ToRGB(p=1.0),


### PR DESCRIPTION
## What?
 
When transforming 16 to 8 bit for validation purposes, enable CLAHE.
 
## Why?
 
We use CLAHE in our products since it yields a better contrast, would be interesting to know if it has a significant impact in validation while training.
 
## How?
 
Simple change probability from 0 to 1.

## Backout plan

Switch back to 0 prob.