### PR TITLE
`imread` compatible with 16bit pngs

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -228,9 +228,9 @@ class BaseDataset(Dataset):
                 except Exception as e:
                     LOGGER.warning(f"{self.prefix}Removing corrupt *.npy image file {fn} due to: {e}")
                     Path(fn).unlink(missing_ok=True)
-                    im = imread(f, flags=self.cv2_flag)  # BGR
+                    im = imread(f, flags=self.cv2_flag, augment=self.augment)  # BGR
             else:  # read image
-                im = imread(f, flags=self.cv2_flag)  # BGR
+                im = imread(f, flags=self.cv2_flag, augment=self.augment)  # BGR
             if im is None:
                 raise FileNotFoundError(f"Image Not Found {f}")
 
@@ -278,7 +278,7 @@ class BaseDataset(Dataset):
         """Save an image as an *.npy file for faster loading."""
         f = self.npy_files[i]
         if not f.exists():
-            np.save(f.as_posix(), imread(self.im_files[i], flags=self.cv2_flag), allow_pickle=False)
+            np.save(f.as_posix(), imread(self.im_files[i]), allow_pickle=False)
 
     def check_cache_disk(self, safety_margin=0.5):
         """

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -204,21 +204,6 @@ class BaseDataset(Dataset):
             if self.single_cls:
                 self.labels[i]["cls"][:, 0] = 0
 
-    def imread_16bit_compatible(self, f: str) -> np.ndarray:
-        """Read image with OpenCV, convert from 16-bit to 8-bit if necessary"""
-        im = cv2.imread(f, cv2.IMREAD_UNCHANGED)  # load image as BGR if 3-ch image
-        if im.dtype == np.uint8 and (im.ndim == 2 or im.shape[-1] == 1):
-            im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)  # BGR
-        if im.dtype == np.uint16:
-            try:
-                from .augment16 import convert_16bit_to_8bit
-
-                im = convert_16bit_to_8bit(im, augment=self.augment)  # GRAY as BGR
-            except Exception as e:
-                print(f"WARNING: Failed to convert image {f} from 16-bit to 8-bit")
-                raise e
-        return im
-
     def load_image(self, i, rect_mode=True):
         """
         Load an image from dataset index 'i'.
@@ -245,10 +230,7 @@ class BaseDataset(Dataset):
                     Path(fn).unlink(missing_ok=True)
                     im = imread(f, flags=self.cv2_flag)  # BGR
             else:  # read image
-                if self.cv2_flag == cv2.IMREAD_COLOR:
-                    im = self.imread_16bit_compatible(f)  # BGR
-                else:
-                    im = imread(f, flags=self.cv2_flag)  # BGR
+                im = imread(f, flags=self.cv2_flag)  # BGR
             if im is None:
                 raise FileNotFoundError(f"Image Not Found {f}")
 
@@ -296,7 +278,7 @@ class BaseDataset(Dataset):
         """Save an image as an *.npy file for faster loading."""
         f = self.npy_files[i]
         if not f.exists():
-            np.save(f.as_posix(), self.imread_16bit_compatible(self.im_files[i]), allow_pickle=False)
+            np.save(f.as_posix(), imread(self.im_files[i], flags=self.cv2_flag), allow_pickle=False)
 
     def check_cache_disk(self, safety_margin=0.5):
         """
@@ -347,7 +329,7 @@ class BaseDataset(Dataset):
         b, gb = 0, 1 << 30  # bytes of cached images, bytes per gigabytes
         n = min(self.ni, 30)  # extrapolate from 30 random images
         for _ in range(n):
-            im = self.imread_16bit_compatible(random.choice(self.im_files))  # sample image
+            im = imread(random.choice(self.im_files))  # sample image
             if im is None:
                 continue
             ratio = self.imgsz / max(im.shape[0], im.shape[1])  # max(h, w)  # ratio

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -13,13 +13,14 @@ import torch
 _imshow = cv2.imshow  # copy to avoid recursion errors
 
 
-def imread(filename: str, flags: int = cv2.IMREAD_COLOR):
+def imread(filename: str, flags: int = cv2.IMREAD_COLOR, augment: bool = False):
     """
     Read an image from a file.
 
     Args:
         filename (str): Path to the file to read.
         flags (int): Flag that can take values of cv2.IMREAD_*. Controls how the image is read.
+        augment (bool): Whether to augment the image during 16 -> 8 bit conversion.
 
     Returns:
         (np.ndarray): The read image.
@@ -34,7 +35,7 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR):
         if im.mode == "I;16":
             from ultralytics.data.augment16 import convert_16bit_to_8bit
 
-            return convert_16bit_to_8bit(np.array(im), augment=False)  # GRAY as BGR
+            return convert_16bit_to_8bit(np.array(im), augment=augment)  # GRAY as BGR
     file_bytes = np.fromfile(filename, np.uint8)
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+from PIL import Image
 import torch
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
@@ -27,6 +28,13 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR):
         >>> img = imread("path/to/image.jpg")
         >>> img = imread("path/to/image.jpg", cv2.IMREAD_GRAYSCALE)
     """
+    if filename.endswith(".png"):
+        # handle 16bit pngs from thermal cameras
+        im = Image.open(filename)  # lazy load
+        if im.mode == "I;16":
+            from ultralytics.data.augment16 import convert_16bit_to_8bit
+
+            return convert_16bit_to_8bit(np.array(im), augment=False)  # GRAY as BGR
     file_bytes = np.fromfile(filename, np.uint8)
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)


### PR DESCRIPTION
## What?
 
Better integration of 16bit image reading compatible with latest changes in the upstream repo. 

## Why?
 
Integration tests are failing because a 10-ch image is expected but a 3-ch image is returned. I did not dig deeper but it seems because of our previous _patch_.
 
## How?
 
Ultralytics moved the image reading logic to `ultralytics.utils.patches` so the 16-bit image reading is now applied only if the filename points to a PNG and if pillow says it has 16bit pixel format (`I;16`)

It seems that `PIL.Image.open` does lazy loading, so performance should be ok. https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open

## Backout plan

Remove the 16bit part from the `imread` function inside `ultralytics.utils.patches` 
 
## Testing
 
```python
from PIL import Image
from ultralytics.utils.patches import imread

im_16bit = imread(".../Sentry_TnFoV_snapshot_0174_2025_05_05_23_26_16.png", augment=True)
im_8bit = imread(".../Sentry_RGBnFoV_snapshot_0174_2025_05_05_23_26_16.jpeg", augment=True)
print(im_16bit.shape, im_8bit.shape)

>>> (512, 640, 3) (960, 1200, 3)
```

<img width="675" alt="image" src="https://github.com/user-attachments/assets/18c116a3-42bb-46c6-8b43-222934e6a4da" />

<img width="633" alt="image" src="https://github.com/user-attachments/assets/696ea841-617f-427f-944b-c8764b5a6c62" />

