### PR TITLE
Fix IsolatedExports CI broken by import-time stdout print

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -14,8 +14,6 @@ from ultralytics.utils import ASSETS, SETTINGS
 from ultralytics.utils.checks import check_yolo as checks
 from ultralytics.utils.downloads import download
 
-print("🚀 SEA.AI custom version")
-
 settings = SETTINGS
 
 MODELS = ("YOLO", "YOLOWorld", "YOLOE", "NAS", "SAM", "FastSAM", "RTDETR")

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 __version__ = "8.4.61"
+__brand__ = "SEA.AI 🔱"
 
 import importlib
 import os
@@ -20,6 +21,7 @@ MODELS = ("YOLO", "YOLOWorld", "YOLOE", "NAS", "SAM", "FastSAM", "RTDETR")
 
 __all__ = (
     "__version__",
+    "__brand__",
     "ASSETS",
     *MODELS,
     "checks",

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from ultralytics import __version__
+from ultralytics import __brand__, __version__
 from ultralytics.utils import (
     ASSETS,
     DEFAULT_CFG,
@@ -904,7 +904,7 @@ def entrypoint(debug: str = "") -> None:
 
     special = {
         "checks": checks.collect_system_info,
-        "version": lambda: LOGGER.info(__version__),
+        "version": lambda: LOGGER.info(f"{__version__} {__brand__}"),
         "settings": lambda: handle_yolo_settings(args[1:]),
         "cfg": lambda: YAML.print(DEFAULT_CFG_PATH),
         "hub": lambda: handle_yolo_hub(args[1:]),

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -20,7 +20,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ultralytics import __version__
+from ultralytics import __brand__, __version__
 from ultralytics.utils import (
     DEFAULT_CFG_DICT,
     DEFAULT_CFG_KEYS,
@@ -164,7 +164,7 @@ def select_device(device="", newline=False, verbose=True):
     if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
-    s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "
+    s = f"Ultralytics {__version__} 🚀 {__brand__} Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
         device = device.replace(remove, "")  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Remove the import-time `print()` that broke IsolatedExports CI
- Add `__brand__ = "SEA.AI 🔱"` shown in `yolo version` and the train/val/predict banner

## Why
The IsolatedExports CI job parses stdout from:

```bash
for env in $(python .github/scripts/create-export-env.py --list); do
```

Importing `ultralytics` printed `🚀 SEA.AI custom version` to stdout, so the shell loop treated `🚀` as an export env id:

```
create-export-env.py: error: argument --env: invalid choice: '🚀'
```

Branding was moved to intentional CLI surfaces instead of import time.

## How
- **`ultralytics/__init__.py`**: define `__brand__ = "SEA.AI 🔱"`, no import-time print
- **`ultralytics/cfg/__init__.py`**: `yolo version` → `{__version__} {__brand__}`
- **`ultralytics/utils/torch_utils.py`**: banner → `Ultralytics {__version__} 🚀 {__brand__} Python-...`

## Example output

```text
$ yolo version
8.4.61 SEA.AI 🔱

$ yolo train model=yolo26n.pt data=coco8.yaml epochs=1
Ultralytics 8.4.61 🚀 SEA.AI 🔱 Python-3.13.13 torch-2.8.0 CPU (...)
```

## Testing
- Root cause confirmed from CI log (stdout pollution from import)
- Import is silent — safe for `create-export-env.py --list`
- Branding visible via `yolo version` and `select_device` banner only

<img width="733" height="22" alt="2026-06-08_00-45-34" src="https://github.com/user-attachments/assets/175e5d9b-0b63-4018-a71e-80053e8b6036" />

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94f539d2-6263-49e7-a692-c7ccea8ddf2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94f539d2-6263-49e7-a692-c7ccea8ddf2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

