### PR TITLE
Add horizon-gated OBB visualization and yolo11p-obb scale

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -229,7 +229,7 @@ def test_track_second_association_indices():
     """Low-confidence detections matched in second association keep full detection-set indices."""
     from ultralytics.engine.results import Boxes
     from ultralytics.trackers.byte_tracker import BYTETracker
-    from ultralytics.utils import ROOT, IterableSimpleNamespace, YAML
+    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
 
     args = IterableSimpleNamespace(**{**YAML.load(ROOT / "cfg/trackers/bytetrack.yaml"), "fuse_score": False})
     tracker = BYTETracker(args)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -667,6 +667,7 @@ def test_utils_ops():
         xywh2ltwh,
         xywh2xyxy,
         xywhn2xyxy,
+        xywhr2line,
         xywhr2xyxyxyxy,
         xyxy2ltwh,
         xyxy2xywh,
@@ -685,6 +686,26 @@ def test_utils_ops():
     boxes = torch.rand(10, 5)  # xywhr for OBB
     boxes[:, 4] = torch.randn(10) * 30
     torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
+
+    # xywhr2line: canonicalize thin boxes so line follows the long axis
+    horizontal = torch.tensor([[320.0, 240.0, 400.0, 5.0, 0.0]])
+    h_line = xywhr2line(horizontal)[0]
+    assert abs(h_line[0, 1] - h_line[1, 1]) < 1e-3
+    vertical = torch.tensor([[320.0, 240.0, 5.0, 400.0, 0.0]])
+    v_line = xywhr2line(vertical)[0]
+    assert abs(v_line[0, 0] - v_line[1, 0]) < 1e-3
+
+
+def test_horizon_top_conf_index():
+    """Test top-confidence index helper used by horizon plotting."""
+    import numpy as np
+
+    from ultralytics.utils.plotting import top_conf_index
+
+    assert top_conf_index(None) is None
+    assert top_conf_index(np.array([0.5])) is None
+    assert top_conf_index(np.array([0.3, 0.9, 0.1])) == 1
+    assert top_conf_index(torch.tensor([0.2, 0.4, 0.8])) == 2
 
 
 def test_utils_files(tmp_path):

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -131,6 +131,7 @@ copy_paste_mode: flip # (str) copy-paste strategy for segmentation: flip or mixu
 auto_augment: randaugment # (str) classification auto augmentation policy: randaugment, autoaugment, augmix
 erasing: 0.4 # (float) random erasing probability for classification (0.0–1.0)
 fill_value: 114 # (int) fill value for letterbox & mosaic (default 114)
+horizon: False # (bool) plot OBB predictions as horizon lines instead of standard rotated boxes
 
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg: # (str, optional) path to a config.yaml that overrides defaults

--- a/ultralytics/cfg/models/11/yolo11-obb.yaml
+++ b/ultralytics/cfg/models/11/yolo11-obb.yaml
@@ -8,6 +8,7 @@
 nc: 80 # number of classes
 scales: # model compound scaling constants, i.e. 'model=yolo11n-obb.yaml' will call yolo11-obb.yaml with scale 'n'
   # [depth, width, max_channels]
+  p: [0.50, 0.25, 512] # summary: 196 layers, 1583747 parameters, 1583731 gradients, 5.9 GFLOPs
   n: [0.50, 0.25, 1024] # summary: 196 layers, 2695747 parameters, 2695731 gradients, 6.9 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 196 layers, 9744931 parameters, 9744915 gradients, 22.7 GFLOPs
   m: [0.50, 1.00, 512] # summary: 246 layers, 20963523 parameters, 20963507 gradients, 72.2 GFLOPs

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -454,7 +454,7 @@ class BasePredictor:
                 conf=self.args.show_conf,
                 labels=self.args.show_labels,
                 im_gpu=None if self.args.retina_masks else im[i],
-                horizon=getattr(self.args, "horizon", False),
+                horizon=self.args.horizon,
             )
 
         # Save results

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -454,6 +454,7 @@ class BasePredictor:
                 conf=self.args.show_conf,
                 labels=self.args.show_labels,
                 im_gpu=None if self.args.retina_masks else im[i],
+                horizon=getattr(self.args, "horizon", False),
             )
 
         # Save results

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -552,7 +552,11 @@ class Results(SimpleClass, DataExportMixin):
 
         # Plot Detect results
         if pred_boxes is not None and show_boxes:
-            for i, d in enumerate(reversed(pred_boxes)):
+            boxes_to_plot = pred_boxes
+            if horizon and is_obb and len(pred_boxes) > 1:
+                top_idx = int(pred_boxes.conf.argmax())
+                boxes_to_plot = pred_boxes[top_idx : top_idx + 1]
+            for i, d in enumerate(reversed(boxes_to_plot)):
                 c, d_conf, id = int(d.cls), float(d.conf) if conf else None, int(d.id.item()) if d.is_track else None
                 name = ("" if id is None else f"id:{id} ") + names[c]
                 label = (f"{name} {d_conf:.2f}" if conf else name) if labels else (f"{d_conf:.2f}" if conf else None)
@@ -561,7 +565,7 @@ class Results(SimpleClass, DataExportMixin):
                     True,
                 )
                 if horizon and is_obb:
-                    line = ops.xywhr2line(d.xywhr.squeeze())
+                    line = ops.xywhr2line(d.xywhr.squeeze(), canonical=True)
                     box = d.xyxyxyxy.reshape(-1, 4, 2).squeeze()
                     annotator.box_label(box, label, color=(0, 0, 0))
                     annotator.line_label(line, label, color=color)

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -478,6 +478,7 @@ class Results(SimpleClass, DataExportMixin):
         filename: str | None = None,
         color_mode: str = "class",
         txt_color: tuple[int, int, int] = (255, 255, 255),
+        horizon: bool = False,
     ) -> np.ndarray:
         """Plot detection results on an input BGR image.
 
@@ -500,6 +501,7 @@ class Results(SimpleClass, DataExportMixin):
             filename (str | None): Filename to save image if save is True.
             color_mode (str): Specify the color mode, e.g., 'instance' or 'class'.
             txt_color (tuple[int, int, int]): Text color in BGR format for classification output.
+            horizon (bool): Plot OBB predictions as horizon lines instead of standard rotated boxes.
 
         Returns:
             (np.ndarray | PIL.Image.Image): Annotated image as a NumPy array (BGR) or PIL image (RGB) if `pil=True`.
@@ -554,21 +556,24 @@ class Results(SimpleClass, DataExportMixin):
                 c, d_conf, id = int(d.cls), float(d.conf) if conf else None, int(d.id.item()) if d.is_track else None
                 name = ("" if id is None else f"id:{id} ") + names[c]
                 label = (f"{name} {d_conf:.2f}" if conf else name) if labels else (f"{d_conf:.2f}" if conf else None)
-                box = d.xyxyxyxy.squeeze() if is_obb else d.xyxy.squeeze()
-                annotator.box_label(
-                    box,
-                    label,
-                    color=colors(
-                        c
-                        if color_mode == "class"
-                        else id
-                        if id is not None
-                        else i
-                        if color_mode == "instance"
-                        else None,
-                        True,
-                    ),
+                color = colors(
+                    c
+                    if color_mode == "class"
+                    else id
+                    if id is not None
+                    else i
+                    if color_mode == "instance"
+                    else None,
+                    True,
                 )
+                if horizon and is_obb:
+                    line = ops.xywhr2line(d.xywhr.squeeze())
+                    box = d.xyxyxyxy.reshape(-1, 4, 2).squeeze()
+                    annotator.box_label(box, label, color=(0, 0, 0))
+                    annotator.line_label(line, label, color=color)
+                else:
+                    box = d.xyxyxyxy.squeeze() if is_obb else d.xyxy.squeeze()
+                    annotator.box_label(box, label, color=color)
 
         # Plot Classify results
         if pred_probs is not None and show_probs:

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -557,13 +557,7 @@ class Results(SimpleClass, DataExportMixin):
                 name = ("" if id is None else f"id:{id} ") + names[c]
                 label = (f"{name} {d_conf:.2f}" if conf else name) if labels else (f"{d_conf:.2f}" if conf else None)
                 color = colors(
-                    c
-                    if color_mode == "class"
-                    else id
-                    if id is not None
-                    else i
-                    if color_mode == "instance"
-                    else None,
+                    c if color_mode == "class" else id if id is not None else i if color_mode == "instance" else None,
                     True,
                 )
                 if horizon and is_obb:

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -17,7 +17,7 @@ import torch
 
 from ultralytics.data.augment import LetterBox
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, ops
-from ultralytics.utils.plotting import Annotator, colors, save_one_box
+from ultralytics.utils.plotting import Annotator, colors, save_one_box, top_conf_index
 
 
 class BaseTensor(SimpleClass):
@@ -553,9 +553,8 @@ class Results(SimpleClass, DataExportMixin):
         # Plot Detect results
         if pred_boxes is not None and show_boxes:
             boxes_to_plot = pred_boxes
-            if horizon and is_obb and len(pred_boxes) > 1:
-                top_idx = int(pred_boxes.conf.argmax())
-                boxes_to_plot = pred_boxes[top_idx : top_idx + 1]
+            if horizon and is_obb and (idx := top_conf_index(pred_boxes.conf)) is not None:
+                boxes_to_plot = pred_boxes[idx : idx + 1]
             for i, d in enumerate(reversed(boxes_to_plot)):
                 c, d_conf, id = int(d.cls), float(d.conf) if conf else None, int(d.id.item()) if d.is_track else None
                 name = ("" if id is None else f"id:{id} ") + names[c]
@@ -564,13 +563,11 @@ class Results(SimpleClass, DataExportMixin):
                     c if color_mode == "class" else id if id is not None else i if color_mode == "instance" else None,
                     True,
                 )
+                box = d.xyxyxyxy.reshape(-1, 4, 2).squeeze() if is_obb else d.xyxy.squeeze()
                 if horizon and is_obb:
-                    line = ops.xywhr2line(d.xywhr.squeeze(), canonical=True)
-                    box = d.xyxyxyxy.reshape(-1, 4, 2).squeeze()
-                    annotator.box_label(box, label, color=(0, 0, 0))
-                    annotator.line_label(line, label, color=color)
+                    line = ops.xywhr2line(d.xywhr.squeeze())
+                    annotator.horizon(line, box, label, color)
                 else:
-                    box = d.xyxyxyxy.squeeze() if is_obb else d.xyxy.squeeze()
                     annotator.box_label(box, label, color=color)
 
         # Plot Classify results

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -243,6 +243,7 @@ class DetectionTrainer(BaseTrainer):
             paths=batch["im_file"],
             fname=self.save_dir / f"train_batch{ni}.jpg",
             on_plot=self.on_plot,
+            horizon=getattr(self.args, "horizon", False),
         )
 
     def plot_training_labels(self):

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -374,6 +374,7 @@ class DetectionValidator(BaseValidator):
             fname=self.save_dir / f"val_batch{ni}_labels.jpg",
             names=self.names,
             on_plot=self.on_plot,
+            horizon=getattr(self.args, "horizon", False),
         )
 
     def plot_predictions(
@@ -402,6 +403,7 @@ class DetectionValidator(BaseValidator):
             fname=self.save_dir / f"val_batch{ni}_pred.jpg",
             names=self.names,
             on_plot=self.on_plot,
+            horizon=getattr(self.args, "horizon", False),
         )  # pred
 
     def save_one_txt(self, predn: dict[str, torch.Tensor], save_conf: bool, shape: tuple[int, int], file: Path) -> None:

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import OBBModel
 from ultralytics.utils import DEFAULT_CFG, RANK
+from ultralytics.utils.plotting import plot_images
 
 
 class OBBTrainer(yolo.detect.DetectionTrainer):
@@ -69,6 +70,16 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
             model.load(weights)
 
         return model
+
+    def plot_training_samples(self, batch, ni: int) -> None:
+        """Plot training samples with optional horizon-line visualization for OBB."""
+        plot_images(
+            labels=batch,
+            paths=batch["im_file"],
+            fname=self.save_dir / f"train_batch{ni}.jpg",
+            on_plot=self.on_plot,
+            horizon=self.args.horizon,
+        )
 
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import OBBModel
 from ultralytics.utils import DEFAULT_CFG, RANK
-from ultralytics.utils.plotting import plot_images
 
 
 class OBBTrainer(yolo.detect.DetectionTrainer):
@@ -70,16 +69,6 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
             model.load(weights)
 
         return model
-
-    def plot_training_samples(self, batch, ni: int) -> None:
-        """Plot training samples with optional horizon-line visualization for OBB."""
-        plot_images(
-            labels=batch,
-            paths=batch["im_file"],
-            fname=self.save_dir / f"train_batch{ni}.jpg",
-            on_plot=self.on_plot,
-            horizon=self.args.horizon,
-        )
 
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -168,6 +168,18 @@ class OBBValidator(DetectionValidator):
             fname=self.save_dir / f"val_batch{ni}_pred.jpg",
             names=self.names,
             on_plot=self.on_plot,
+            horizon=self.args.horizon,
+        )
+
+    def plot_val_samples(self, batch, ni: int) -> None:
+        """Plot validation image samples with optional horizon-line visualization for OBB."""
+        plot_images(
+            labels=batch,
+            paths=batch["im_file"],
+            fname=self.save_dir / f"val_batch{ni}_labels.jpg",
+            names=self.names,
+            on_plot=self.on_plot,
+            horizon=self.args.horizon,
         )
 
     def pred_to_json(self, predn: dict[str, torch.Tensor], pbatch: dict[str, Any]) -> None:

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -168,18 +168,7 @@ class OBBValidator(DetectionValidator):
             fname=self.save_dir / f"val_batch{ni}_pred.jpg",
             names=self.names,
             on_plot=self.on_plot,
-            horizon=self.args.horizon,
-        )
-
-    def plot_val_samples(self, batch, ni: int) -> None:
-        """Plot validation image samples with optional horizon-line visualization for OBB."""
-        plot_images(
-            labels=batch,
-            paths=batch["im_file"],
-            fname=self.save_dir / f"val_batch{ni}_labels.jpg",
-            names=self.names,
-            on_plot=self.on_plot,
-            horizon=self.args.horizon,
+            horizon=getattr(self.args, "horizon", False),
         )
 
     def pred_to_json(self, predn: dict[str, torch.Tensor], pbatch: dict[str, Any]) -> None:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -404,13 +404,13 @@ def xywhr2xyxyxyxy(x):
     return stack([pt1, pt2, pt3, pt4], -2)
 
 
-def xywhr2line(x, canonical: bool = False):
-    """Convert batched OBB boxes from [xywh, rotation] to line endpoints through the box center.
+def xywhr2line(x):
+    """Convert batched OBB boxes from [xywh, rotation] to horizon line endpoints through the box center.
+
+    Width and height are canonicalized so the line follows the long axis (required for thin horizon boxes).
 
     Args:
         x (np.ndarray | torch.Tensor): Boxes in [cx, cy, w, h, rotation] format with shape (N, 5) or (B, N, 5).
-        canonical (bool): If True, swap width/height when h > w and rotate angle by pi/2 so the line follows the long
-            axis. Use for horizon visualization where boxes are very thin.
 
     Returns:
         (np.ndarray | torch.Tensor): Line endpoints with shape (N, 2, 2) or (B, N, 2, 2) as [[x1, y1], [x2, y2]].
@@ -423,10 +423,9 @@ def xywhr2line(x, canonical: bool = False):
 
     ctr = x[..., :2]
     w, h, angle = (x[..., i : i + 1] for i in range(2, 5))
-    if canonical:
-        swap = h > w
-        w = torch.where(swap, h, w) if isinstance(x, torch.Tensor) else np.where(swap, h, w)
-        angle = angle + swap * (np.pi / 2)
+    swap = h > w
+    w = torch.where(swap, h, w) if isinstance(x, torch.Tensor) else np.where(swap, h, w)
+    angle = angle + swap * (np.pi / 2)
     cos_value, sin_value = cos(angle), sin(angle)
     vec = cat([w / 2 * cos_value, w / 2 * sin_value], -1)
     return stack([ctr + vec, ctr - vec], -2)

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -404,6 +404,28 @@ def xywhr2xyxyxyxy(x):
     return stack([pt1, pt2, pt3, pt4], -2)
 
 
+def xywhr2line(x):
+    """Convert batched OBB boxes from [xywh, rotation] to line endpoints through the box center.
+
+    Args:
+        x (np.ndarray | torch.Tensor): Boxes in [cx, cy, w, h, rotation] format with shape (N, 5) or (B, N, 5).
+
+    Returns:
+        (np.ndarray | torch.Tensor): Line endpoints with shape (N, 2, 2) or (B, N, 2, 2) as [[x1, y1], [x2, y2]].
+    """
+    cos, sin, cat, stack = (
+        (torch.cos, torch.sin, torch.cat, torch.stack)
+        if isinstance(x, torch.Tensor)
+        else (np.cos, np.sin, np.concatenate, np.stack)
+    )
+
+    ctr = x[..., :2]
+    w, angle = x[..., 2:3], x[..., 4:5]
+    cos_value, sin_value = cos(angle), sin(angle)
+    vec = cat([w / 2 * cos_value, w / 2 * sin_value], -1)
+    return stack([ctr + vec, ctr - vec], -2)
+
+
 def ltwh2xyxy(x):
     """Convert bounding box from [x1, y1, w, h] to [x1, y1, x2, y2] where xy1=top-left, xy2=bottom-right.
 

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -404,11 +404,13 @@ def xywhr2xyxyxyxy(x):
     return stack([pt1, pt2, pt3, pt4], -2)
 
 
-def xywhr2line(x):
+def xywhr2line(x, canonical: bool = False):
     """Convert batched OBB boxes from [xywh, rotation] to line endpoints through the box center.
 
     Args:
         x (np.ndarray | torch.Tensor): Boxes in [cx, cy, w, h, rotation] format with shape (N, 5) or (B, N, 5).
+        canonical (bool): If True, swap width/height when h > w and rotate angle by pi/2 so the line follows the long
+            axis. Use for horizon visualization where boxes are very thin.
 
     Returns:
         (np.ndarray | torch.Tensor): Line endpoints with shape (N, 2, 2) or (B, N, 2, 2) as [[x1, y1], [x2, y2]].
@@ -420,7 +422,11 @@ def xywhr2line(x):
     )
 
     ctr = x[..., :2]
-    w, angle = x[..., 2:3], x[..., 4:5]
+    w, h, angle = (x[..., i : i + 1] for i in range(2, 5))
+    if canonical:
+        swap = h > w
+        w = torch.where(swap, h, w) if isinstance(x, torch.Tensor) else np.where(swap, h, w)
+        angle = angle + swap * (np.pi / 2)
     cos_value, sin_value = cos(angle), sin(angle)
     vec = cat([w / 2 * cos_value, w / 2 * sin_value], -1)
     return stack([ctr + vec, ctr - vec], -2)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -925,7 +925,9 @@ def plot_images(
                         label = f"{c}" if show_labels else ""
                         label += f" {conf_text}".strip() if show_conf else ""
                         if horizon_lines is not None:
-                            annotator.horizon(horizon_lines[j].astype(np.int64).tolist(), box, label, color, label_on="box")
+                            annotator.horizon(
+                                horizon_lines[j].astype(np.int64).tolist(), box, label, color, label_on="box"
+                            )
                         else:
                             annotator.box_label(box, label, color=color)
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -435,6 +435,14 @@ class Annotator:
                     lineType=cv2.LINE_AA,
                 )
 
+    def horizon(self, line, box, label: str = "", color: tuple = (128, 128, 128), *, label_on: str = "line"):
+        """Draw a horizon line and optional OBB box (black). Label is placed on the line or box."""
+        line_label = label if label_on in {"line", "both"} else ""
+        box_label = label if label_on in {"box", "both"} else ""
+        self.line_label(line, line_label, color=color)
+        if box is not None:
+            self.box_label(box, box_label, color=(0, 0, 0))
+
     def masks(self, masks, colors, im_gpu: torch.Tensor = None, alpha: float = 0.5, retina_masks: bool = False):
         """Plot masks on image.
 
@@ -769,6 +777,21 @@ def save_one_box(
     return crop
 
 
+def top_conf_index(conf) -> int | None:
+    """Return index of the top-confidence detection, or None if not applicable."""
+    if conf is None or len(conf) <= 1:
+        return None
+    return int(np.argmax(conf))
+
+
+def _top_conf_slice(conf, *arrays):
+    """Return arrays sliced to the top-confidence detection when multiple confidences are present."""
+    idx = top_conf_index(conf)
+    if idx is None:
+        return arrays
+    return tuple(a[idx : idx + 1] for a in arrays)
+
+
 @threaded
 def plot_images(
     labels: dict[str, Any],
@@ -890,37 +913,20 @@ def plot_images(
                 boxes[..., 1] += y
                 is_obb = boxes.shape[-1] == 5  # xywhr
                 if horizon and is_obb:
-                    obb_boxes = boxes.copy()
-                    if conf is not None and len(conf) > 1:
-                        top_idx = int(np.argmax(conf))
-                        obb_boxes = obb_boxes[top_idx : top_idx + 1]
-                        classes = classes[top_idx : top_idx + 1]
-                        conf = conf[top_idx : top_idx + 1]
-                    lines = ops.xywhr2line(obb_boxes, canonical=True)
-                    for j, line in enumerate(lines.astype(np.int64).tolist()):
-                        c = classes[j]
-                        color = colors(c)
-                        if labels or conf[j] > conf_thres:
-                            annotator.line_label(line, label=None, color=color)
-                    boxes = ops.xywhr2xyxyxyxy(obb_boxes)
-                    for j, box in enumerate(boxes.astype(np.int64).tolist()):
-                        c = classes[j]
-                        c = names.get(c, c) if names else c
-                        if labels or conf[j] > conf_thres:
-                            conf_text = f"{conf[j]:.1f}" if conf is not None else ""
-                            label = f"{c}" if show_labels else ""
-                            label += f" {conf_text}".strip() if show_conf else ""
-                            annotator.box_label(box, label, color=(0, 0, 0))
-                else:
-                    boxes = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
-                    for j, box in enumerate(boxes.astype(np.int64).tolist()):
-                        c = classes[j]
-                        color = colors(c)
-                        c = names.get(c, c) if names else c
-                        if labels or conf[j] > conf_thres:
-                            conf_text = f"{conf[j]:.1f}" if conf is not None else ""
-                            label = f"{c}" if show_labels else ""
-                            label += f" {conf_text}".strip() if show_conf else ""
+                    boxes, classes, conf = _top_conf_slice(conf, boxes, classes, conf)
+                boxes_xyxy = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
+                horizon_lines = ops.xywhr2line(boxes) if horizon and is_obb else None
+                for j, box in enumerate(boxes_xyxy.astype(np.int64).tolist()):
+                    c = classes[j]
+                    color = colors(c)
+                    c = names.get(c, c) if names else c
+                    if labels or conf[j] > conf_thres:
+                        conf_text = f"{conf[j]:.1f}" if conf is not None else ""
+                        label = f"{c}" if show_labels else ""
+                        label += f" {conf_text}".strip() if show_conf else ""
+                        if horizon_lines is not None:
+                            annotator.horizon(horizon_lines[j].astype(np.int64).tolist(), box, label, color, label_on="box")
+                        else:
                             annotator.box_label(box, label, color=color)
 
             elif len(classes):

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -896,7 +896,7 @@ def plot_images(
                         obb_boxes = obb_boxes[top_idx : top_idx + 1]
                         classes = classes[top_idx : top_idx + 1]
                         conf = conf[top_idx : top_idx + 1]
-                    lines = ops.xywhr2line(obb_boxes)
+                    lines = ops.xywhr2line(obb_boxes, canonical=True)
                     for j, line in enumerate(lines.astype(np.int64).tolist()):
                         c = classes[j]
                         color = colors(c)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -925,9 +925,7 @@ def plot_images(
                         label = f"{c}" if show_labels else ""
                         label += f" {conf_text}".strip() if show_conf else ""
                         if horizon_lines is not None:
-                            annotator.horizon(
-                                horizon_lines[j].astype(np.int64).tolist(), box, label, color, label_on="box"
-                            )
+                            annotator.horizon(horizon_lines[j].astype(np.int64).tolist(), box, label, color)
                         else:
                             annotator.box_label(box, label, color=color)
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -379,6 +379,62 @@ class Annotator:
                     lineType=cv2.LINE_AA,
                 )
 
+    def line_label(self, line, label: str = "", color: tuple = (128, 128, 128), txt_color: tuple = (255, 255, 255)):
+        """Draw a line on an image with an optional label at its midpoint.
+
+        Args:
+            line (list | tuple | torch.Tensor): Line endpoints as [[x1, y1], [x2, y2]].
+            label (str, optional): Text label to display above the line midpoint.
+            color (tuple, optional): Line and label background color.
+            txt_color (tuple, optional): Label text color.
+        """
+        txt_color = self.get_txt_color(color, txt_color)
+        if isinstance(line, torch.Tensor):
+            line = line.tolist()
+
+        p1, p2 = line[0], line[1]
+        mid_x = (p1[0] + p2[0]) / 2
+        mid_y = (p1[1] + p2[1]) / 2
+
+        if self.pil:
+            self.draw.line((tuple(p1), tuple(p2)), fill=color, width=self.lw)
+            if label:
+                w, h = self.font.getsize(label)
+                label_pos = (int(mid_x - w / 2), int(mid_y - h - 5))
+                label_pos = (
+                    max(0, min(label_pos[0], self.im.size[0] - w)),
+                    label_pos[1],
+                )
+                self.draw.rectangle(
+                    (label_pos[0], label_pos[1], label_pos[0] + w + 1, label_pos[1] + h + 1),
+                    fill=color,
+                )
+                self.draw.text(label_pos, label, fill=txt_color, font=self.font)
+        else:
+            p1 = (int(p1[0]), int(p1[1]))
+            p2 = (int(p2[0]), int(p2[1]))
+            cv2.line(self.im, p1, p2, color, thickness=self.lw, lineType=cv2.LINE_AA)
+            if label:
+                w, h = cv2.getTextSize(label, 0, fontScale=self.sf, thickness=self.tf)[0]
+                h += 3
+                label_p1 = (int(mid_x - w / 2), int(mid_y - 5))
+                label_p1 = (
+                    max(0, min(label_p1[0], self.im.shape[1] - w)),
+                    label_p1[1],
+                )
+                label_p2 = (label_p1[0] + w, label_p1[1] - h)
+                cv2.rectangle(self.im, label_p1, label_p2, color, -1, cv2.LINE_AA)
+                cv2.putText(
+                    self.im,
+                    label,
+                    (label_p1[0], label_p1[1] - 2),
+                    0,
+                    self.sf,
+                    txt_color,
+                    thickness=self.tf,
+                    lineType=cv2.LINE_AA,
+                )
+
     def masks(self, masks, colors, im_gpu: torch.Tensor = None, alpha: float = 0.5, retina_masks: bool = False):
         """Plot masks on image.
 
@@ -727,6 +783,7 @@ def plot_images(
     conf_thres: float = 0.25,
     show_labels: bool = True,
     show_conf: bool = True,
+    horizon: bool = False,
 ) -> np.ndarray | None:
     """Plot image grid with labels, bounding boxes, masks, and keypoints.
 
@@ -744,6 +801,7 @@ def plot_images(
         conf_thres (float): Confidence threshold for displaying detections.
         show_labels (bool): Whether to display class labels.
         show_conf (bool): Whether to display confidence values.
+        horizon (bool): Whether to plot OBB boxes as horizon lines with optional top-confidence filtering.
 
     Returns:
         (np.ndarray | None): Plotted image grid as a numpy array if save is False, None otherwise.
@@ -831,16 +889,39 @@ def plot_images(
                 boxes[..., 0] += x
                 boxes[..., 1] += y
                 is_obb = boxes.shape[-1] == 5  # xywhr
-                boxes = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
-                for j, box in enumerate(boxes.astype(np.int64).tolist()):
-                    c = classes[j]
-                    color = colors(c)
-                    c = names.get(c, c) if names else c
-                    if labels or conf[j] > conf_thres:
-                        conf_text = f"{conf[j]:.1f}" if conf is not None else ""
-                        label = f"{c}" if show_labels else ""
-                        label += f" {conf_text}".strip() if show_conf else ""
-                        annotator.box_label(box, label, color=color)
+                if horizon and is_obb:
+                    obb_boxes = boxes.copy()
+                    if conf is not None and len(conf) > 1:
+                        top_idx = int(np.argmax(conf))
+                        obb_boxes = obb_boxes[top_idx : top_idx + 1]
+                        classes = classes[top_idx : top_idx + 1]
+                        conf = conf[top_idx : top_idx + 1]
+                    lines = ops.xywhr2line(obb_boxes)
+                    for j, line in enumerate(lines.astype(np.int64).tolist()):
+                        c = classes[j]
+                        color = colors(c)
+                        if labels or conf[j] > conf_thres:
+                            annotator.line_label(line, label=None, color=color)
+                    boxes = ops.xywhr2xyxyxyxy(obb_boxes)
+                    for j, box in enumerate(boxes.astype(np.int64).tolist()):
+                        c = classes[j]
+                        c = names.get(c, c) if names else c
+                        if labels or conf[j] > conf_thres:
+                            conf_text = f"{conf[j]:.1f}" if conf is not None else ""
+                            label = f"{c}" if show_labels else ""
+                            label += f" {conf_text}".strip() if show_conf else ""
+                            annotator.box_label(box, label, color=(0, 0, 0))
+                else:
+                    boxes = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
+                    for j, box in enumerate(boxes.astype(np.int64).tolist()):
+                        c = classes[j]
+                        color = colors(c)
+                        c = names.get(c, c) if names else c
+                        if labels or conf[j] > conf_thres:
+                            conf_text = f"{conf[j]:.1f}" if conf is not None else ""
+                            label = f"{c}" if show_labels else ""
+                            label += f" {conf_text}".strip() if show_conf else ""
+                            annotator.box_label(box, label, color=color)
 
             elif len(classes):
                 for c in classes:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Cherry-picks the useful parts of PR #18 (horizon OBB visualization + pico model scale) while excluding scripts, dataset YAMLs with hard-coded paths, and the unused `yolo11-lite-obb.yaml`.

## Why

Horizon-line plotting should not change default OBB behavior for all users. A dedicated `horizon` flag keeps standard OBB paths untouched.

## How

- **`horizon: False`** added to `default.yaml`
- **`ops.xywhr2line()`** — converts OBB boxes to line endpoints
- **`Annotator.line_label()`** — draws labeled lines
- **`plot_images(horizon=...)`** — when enabled: colored horizon lines, black OBB boxes, top-confidence filter when multiple detections
- **`Results.plot(horizon=...)`** — same behavior for inference plots
- Wired through **OBB train/val** (`self.args.horizon`) and **predictor**
- **`yolo11p-obb`** pico scale added to `yolo11-obb.yaml`

### Usage

```bash
# Training / validation
yolo obb train model=yolo11p-obb.yaml data=your-dataset.yaml horizon=True

# Inference
yolo obb predict model=best.pt source=images horizon=True

# Python API
results = model("image.jpg")
results[0].plot(horizon=True)
```

## Testing

- [x] CI passes
- [x] Verify default OBB plots unchanged with `horizon=False`
- [x] Verify horizon lines render with `horizon=True` on OBB task

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e054329-22c7-4c19-932b-f1bc0e3ca94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e054329-22c7-4c19-932b-f1bc0e3ca94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

